### PR TITLE
Fix rockspec git URL so luarocks install works

### DIFF
--- a/torch_binding/rocks/warp-ctc-scm-1.rockspec
+++ b/torch_binding/rocks/warp-ctc-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "warp-ctc"
 version = "scm-1"
 
 source = {
-   url = "https://github.com/baidu-research/warp-ctc",
+   url = "git://github.com/baidu-research/warp-ctc.git",
 }
 
 description = {


### PR DESCRIPTION
Luarocks doesn't like http URLs for git. Using a `git://` URL allows installing directly from the rockspec (rather than cloning and running `luarocks make`) which is usually how people install rocks:
```
luarocks install http://raw.githubusercontent.com/.../rocks/warp-ctc-scm-1.rockspec
```